### PR TITLE
Removed Typos from Makefile - fixes #6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,20 @@ install:
 	@printf "\e[1;34m>>>\e[0m The following commands that will be executed to install the extension:\n"
 	@printf "\n"
 	@printf "mkdir -p ~/.local/share/gnome-shell/extensions/\n"
-	@printf "cp -r ./chatgpt-gnome-desktop@chat-gpt-gnome-desktop ~/.local/share/gnome-shell/extensions/\n"
+	@printf "cp -r ./chatgpt-gnome-desktop@chatgpt-gnome-desktop ~/.local/share/gnome-shell/extensions/\n"
 	@printf "\n"
 	@read -p ">>> Press ENTER to install the extension."
 	@mkdir -p ~/.local/share/gnome-shell/extensions/
-	@cp -r ./chatgpt-gnome-desktop@chat-gpt-gnome-desktop ~/.local/share/gnome-shell/extensions/
+	@cp -r ./chatgpt-gnome-desktop@chatgpt-gnome-desktop ~/.local/share/gnome-shell/extensions/
 	@printf "\e[1;34m>>>\e[0m The app is now installed, You may log out or press Alt+F2 and then type r to complete the install.\n"
 
 uninstall:
 	@printf "\e[1;34m>>>\e[0m ChatGPT Gnome Desktop Extension\n"
 	@printf "\e[1;34m>>>\e[0m The following commands that will be executed to uninstall the extension:\n"
-	@printf "rm -rf ~/.local/share/gnome-shell/extensions/chatgpt-gnome-desktop@chat-gpt-gnome-desktop"
+	@printf "rm -rf ~/.local/share/gnome-shell/extensions/chatgpt-gnome-desktop@chatgpt-gnome-desktop"
 	@printf "\n"
 	@read -p ">>> Press ENTER to uninstall the extension."
-	@rm -rf ~/.local/share/gnome-shell/extensions/chatgpt-gnome-desktop@chat-gpt-gnome-desktop
+	@rm -rf ~/.local/share/gnome-shell/extensions/chatgpt-gnome-desktop@chatgpt-gnome-desktop
 	@printf "\e[1;34m>>>\e[0m The extension is now uninstalled, You may log out or press Alt+F2 and then type r to complete the install. Thanks for testing the extension. \n"
 
 	

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ EARLY VERSION | WORK IN PROGRESS
 ### HOW TO INSTALL:
 
 - Make sure you have the `gnome-shell-extensions` package installed. It allows you to turn on the Extension.
-- Place the `chatgpt-gnome-desktop@chat-gpt-gnome-desktop` folder in `~/.local/share/gnome-shell/extensions/`
+- Place the `chatgpt-gnome-desktop@chatgpt-gnome-desktop` folder in `~/.local/share/gnome-shell/extensions/`
 - Restart Gnome with `Alt`+`F2` then type `r`
 - Enable the extension inside the Gnome Extensions application.
 - Restart Gnome with `Alt`+`F2` then type `r` or Log out & Log back in to Gnome.


### PR DESCRIPTION
Removed the typos from Makefile. 
This fixes #6 and removes the Typo from the Readme as well. 
(renaming the extension folder to `chatgpt-gnome-desktop@chat-gpt-gnome-desktop` would have worked as well)